### PR TITLE
AWS IoT now requires a short clientId

### DIFF
--- a/javasource/mxawsiot/impl/MqttConnector.java
+++ b/javasource/mxawsiot/impl/MqttConnector.java
@@ -91,7 +91,7 @@ public class MqttConnector {
             //String clientId = "JavaSample";
             String hostname = InetAddress.getLocalHost().getHostName();
             String xasId = Core.getXASId();
-            String clientId = "MxClient_" + xasId + "_" + hostname + "_" + brokerHost + "_" + brokerPort;
+            String clientId = "bluemix-receiver";
             logger.info("new MqttConnection client id " + clientId);
 
             boolean useSsl = (ClientCertificate != null && !ClientCertificate.equals(""));


### PR DESCRIPTION
AWS IoT worked with this module before but it now requires a short clientId.
To make it enable, my changes are:

MqttConnector.java

            // String clientId = "MxClient_" + xasId + "_" + hostname + "_" + brokerHost + "_" + brokerPort;
            String clientId = "bluemix-receiver";

IotThing.java

            // DefaultClientid("DefaultClientid");
            DefaultClientid("bluemix-receiver");

This solution is just temporal.  It is much better to accept clientId for setting from Mendix widget.