### PR TITLE
Changed the unique client ID because the ID format is no longer supported by AWS

### DIFF
--- a/javasource/mxawsiot/impl/MqttConnector.java
+++ b/javasource/mxawsiot/impl/MqttConnector.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Created by ako on 4/26/2016.
@@ -91,7 +92,7 @@ public class MqttConnector {
             //String clientId = "JavaSample";
             String hostname = InetAddress.getLocalHost().getHostName();
             String xasId = Core.getXASId();
-            String clientId = "MxClient_" + xasId + "_" + hostname + "_" + brokerHost + "_" + brokerPort;
+            String clientId = UUID.randomUUID().toString();
             logger.info("new MqttConnection client id " + clientId);
 
             boolean useSsl = (ClientCertificate != null && !ClientCertificate.equals(""));


### PR DESCRIPTION
Changed the unique client ID because the ID format is no longer supported by AWS